### PR TITLE
Http protocol. Fix issue with jwk-endpoint.

### DIFF
--- a/src/ring/middleware/jwk.clj
+++ b/src/ring/middleware/jwk.clj
@@ -7,4 +7,5 @@
   [url key-id]
   (-> (URL. url)
       (UrlJwkProvider.)
-      (.get key-id)))
+      (.get key-id)
+      (.getPublicKey)))

--- a/src/ring/middleware/token.clj
+++ b/src/ring/middleware/token.clj
@@ -36,7 +36,7 @@
                             #(contains? #{:HS256} (:alg %))))
 
 (s/def ::public-key #(instance? PublicKey %))
-(s/def ::jwk-endpoint (s/and string? #(re-matches #"(?i)^https://.+$" %)))
+(s/def ::jwk-endpoint (s/and string? #(re-matches #"(?i)^https?://.+$" %)))
 (s/def ::key-id (s/and string? (complement clojure.string/blank?)))
 (s/def ::public-key-opts (s/and #(contains? #{:RS256} (:alg %))
                                 (s/or :key (s/keys :req-un [::alg ::public-key])

--- a/test/ring/middleware/jwt_test.clj
+++ b/test/ring/middleware/jwt_test.clj
@@ -4,7 +4,8 @@
             [clojure.test :refer :all]
             [ring.middleware.jwt-test-utils :as util]
             [ring.middleware.jwt :refer [wrap-jwt]])
-  (:import (clojure.lang ExceptionInfo)))
+  (:import (clojure.lang ExceptionInfo)
+           (java.util UUID)))
 
 (def ^:private dummy-handler (constantly identity))
 
@@ -141,4 +142,9 @@
   (deftest extra-unsupported-option-does-not-cause-error
     (wrap-jwt (dummy-handler) {:alg    :HS256
                                :secret "somesecret"
-                               :bollox "whatever"})))
+                               :bollox "whatever"}))
+
+  (deftest http-protocol-in-jwk-endpoint-does-not-cause-error
+    (wrap-jwt (dummy-handler) {:alg          :RS256
+                               :jwk-endpoint "http://my/jwk"
+                               :key-id       (str (UUID/randomUUID))})))


### PR DESCRIPTION
* Add ability to use http protocol in jwk-endpoint uri. (useful for development with local auth server)
* Fix issue with retrieving jwk