### PR TITLE
support caching jwks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ supported for the purposes of JWS:
 | Algorithm                      | Options                                       |
 | ------------------------------ | --------------------------------------------- |
 | RSASSA-PKCS-v1_5 using SHA-256 | `{:alg :RS256 :public-key public-key}` <sup>[1]</sup> |
-|                                | `{:alg :RS256 :jwk-endpoint "https://your/jwk/endpoint :key-id "key-id"}` | 
+|                                | `{:alg :RS256 :jwk-endpoint "https://your/jwk/endpoint :key-id "key-id" :cache true}` <sup>[2]</sup> | 
 | HMAC using SHA-256             | `{:alg :HS256 :public-key "your-secret"}`     |
 
 [1] `public-key` is of type `java.security.PublicKey`.
+
+[2] when `cache` is set to true, jwks are cached using lru-cache. Cache threshold is equal to 10.
 
 Additionally, the following optional options are supported:
 

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[cheshire "5.8.0"]
                  [commons-codec "1.11"]
                  [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.cache "0.7.1"]
                  [com.auth0/java-jwt "3.3.0"]
                  [com.auth0/jwks-rsa "0.4.0"]]
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]

--- a/src/ring/middleware/token.clj
+++ b/src/ring/middleware/token.clj
@@ -2,7 +2,8 @@
   (:require [cheshire.core :as json]
             [clojure.walk :refer [keywordize-keys]]
             [ring.middleware.jwk :as jwk]
-            [clojure.spec.alpha :as s])
+            [clojure.spec.alpha :as s]
+            [clojure.core.cache :as cache])
   (:import (com.auth0.jwt.algorithms Algorithm)
            (com.auth0.jwt JWT)
            (com.auth0.jwt.exceptions JWTDecodeException)
@@ -31,6 +32,9 @@
 (s/def ::alg #{:RS256 :HS256})
 (s/def ::leeway nat-int?)
 
+(s/def ::cache boolean?)
+(s/def ::cache-max-entries nat-int?)
+
 (s/def ::secret (s/and string? (complement clojure.string/blank?)))
 (s/def ::secret-opts (s/and (s/keys :req-un [::alg ::secret])
                             #(contains? #{:HS256} (:alg %))))
@@ -40,7 +44,8 @@
 (s/def ::key-id (s/and string? (complement clojure.string/blank?)))
 (s/def ::public-key-opts (s/and #(contains? #{:RS256} (:alg %))
                                 (s/or :key (s/keys :req-un [::alg ::public-key])
-                                      :url (s/keys :req-un [::alg ::jwk-endpoint ::key-id]))))
+                                      :url (s/keys :req-un [::alg ::jwk-endpoint ::key-id]
+                                                   :opt-un [::cache ::cache-max-entries]))))
 
 (defmulti decode
           "Decodes and verifies the signature of the given JWT token. The decoded claims from the token are returned."
@@ -49,13 +54,27 @@
   [& _]
   (throw (JWTDecodeException. "Could not parse algorithm.")))
 
+(def jwk-cache (atom (cache/lru-cache-factory {} :threshold 10)))
+
+(defn- get-cached-item [c v-fn & k]
+  (-> c
+      (swap! cache/through-cache k (fn [k]
+                                     (apply v-fn k)))
+      (get k)))
+
+(defn with-cache [cache f & args]
+  (if cache
+    (apply get-cached-item cache f args)
+    (apply f args)))
+
 (defmethod decode :RS256
   [token {:keys [public-key jwk-endpoint key-id leeway-seconds] :as opts}]
   {:pre [(s/valid? ::public-key-opts opts)]}
 
-  (let [[public-key-type _] (s/conform ::public-key-opts opts)]
+  (let [[public-key-type _] (s/conform ::public-key-opts opts)
+        cache (if (:cache opts) jwk-cache)]
     (-> (Algorithm/RSA256 (case public-key-type
-                            :url (jwk/get-jwk jwk-endpoint key-id)
+                            :url (with-cache cache jwk/get-jwk jwk-endpoint key-id)
                             :key public-key))
         (decode-token* token leeway-seconds))))
 


### PR DESCRIPTION
* Add ability to cache jwks with _:cache_ option. Motivation: retrieving jwk from auth server each time can be ineffiecient.