### PR TITLE
Pub key lookup via fn as well as a finder fn to locate the JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 .idea
 /target
 /classes

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target
 /classes
 pom.xml

--- a/README.md
+++ b/README.md
@@ -44,20 +44,31 @@ supported for the purposes of JWS:
 | ------------------------------ | --------------------------------------------- |
 | RSASSA-PKCS-v1_5 using SHA-256 | `{:alg :RS256 :public-key public-key}` <sup>[1]</sup> |
 |                                | `{:alg :RS256 :jwk-endpoint "https://your/jwk/endpoint"}` | 
+|                                | `{:alg :RS256 :key-fn kid->pk }` <sup>[2]</sup> |
 | HMAC using SHA-256             | `{:alg :HS256 :public-key "your-secret"}`     |
 
 [1] `public-key` is of type `java.security.PublicKey`.
+
+[2] `kid->pk` is a user-provided fn that takes a key id (^String from the "kid" header in the JWT) and returns a `java.security.PublicKey`.
 
 Additionally, the following optional options are supported:
 
 * `leeway-seconds`: The number of seconds leeway to give when verifying the expiry/active from claims
 of the token (i.e. the `exp` and `nbf` claims).
 * `issuer`: The issuer of the token, if this does not match the issuer on a token a `401` will be returned.
+* `finder`: A fn taking a ring request and returning the JWT to decode
 
 ### Finding the token on the request
-Currently the library looks in order from the following locations:
+
+By default the library looks in order from the following locations:
 
 1. `Authorization` header bearer token (i.e. an `Authorization` HTTP header of the form "Bearer TOKEN")
+
+If the token is in a different location, use the `finder` option to extract the token from the [Ring](https://github.com/ring-clojure/ring/blob/master/SPEC) request.
+Example: 
+```
+(fn [req] (get-in req [:headers "x-authorization"]))
+```
 
 ## Useful links
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/ring-jwt "1.0.1"
+(defproject ovotech/ring-jwt "1.1.0"
   :description "JWT middleware for Ring"
   :url "http://github.com/ovotech/ring-jwt"
   :license {:name "Eclipse Public License"

--- a/src/ring/middleware/jwk.clj
+++ b/src/ring/middleware/jwk.clj
@@ -15,3 +15,15 @@
             (.getPublicKey)))
       (getPrivateKey [_] nil)
       (getPrivateKeyId [_] nil))))
+
+(defn ^RSAKeyProvider simple-jwk-provider
+  "Creates a provider that gets a public key from the kid attribut by calling a user provided fn"
+  [key-fn]
+  (reify RSAKeyProvider
+    (getPublicKeyById [_, key-id]
+      (key-fn key-id)
+      )
+    (getPrivateKey [_] nil)
+    (getPrivateKeyId [_] nil)
+    )
+  )

--- a/src/ring/middleware/token.clj
+++ b/src/ring/middleware/token.clj
@@ -32,6 +32,7 @@
 (s/def ::alg #{:RS256 :HS256})
 (s/def ::issuer (s/and string? (complement clojure.string/blank?)))
 (s/def ::leeway-seconds nat-int?)
+(s/def ::finder fn?)
 
 (s/def ::secret (s/and string? (complement clojure.string/blank?)))
 (s/def ::secret-opts (s/and (s/keys :req-un [::alg ::secret])
@@ -39,9 +40,11 @@
 
 (s/def ::public-key #(instance? PublicKey %))
 (s/def ::jwk-endpoint (s/and string? #(re-matches #"(?i)^https?://.+$" %)))
+(s/def ::key-fn fn?)
 (s/def ::public-key-opts (s/and #(contains? #{:RS256} (:alg %))
                                 (s/or :key (s/keys :req-un [::alg ::public-key])
-                                      :url (s/keys :req-un [::alg ::jwk-endpoint]))))
+                                      :url (s/keys :req-un [::alg ::jwk-endpoint])
+                                      :key-fn (s/keys :req-un [::alg ::key-fn]))))
 
 (defmulti decode
           "Decodes and verifies the signature of the given JWT token. The decoded claims from the token are returned."
@@ -51,13 +54,15 @@
   (throw (JWTDecodeException. "Could not parse algorithm.")))
 
 (defmethod decode :RS256
-  [token {:keys [public-key jwk-endpoint] :as opts}]
+  [token {:keys [public-key jwk-endpoint key-fn] :as opts}]
   {:pre [(s/valid? ::public-key-opts opts)]}
 
   (let [[public-key-type _] (s/conform ::public-key-opts opts)]
     (-> (Algorithm/RSA256 (case public-key-type
                             :url (jwk/jwk-provider jwk-endpoint)
-                            :key public-key))
+                            :key public-key
+                            :key-fn (jwk/simple-jwk-provider key-fn)
+                            ))
         (decode-token* token opts))))
 
 (defmethod decode :HS256

--- a/test/ring/middleware/token_rsa256_test.clj
+++ b/test/ring/middleware/token_rsa256_test.clj
@@ -45,6 +45,21 @@
                                   :jwk-endpoint jwk-endpoint})
              payload)))))
 
+(deftest can-decode-token-based-on-key-fn
+  (let [payload      {:field1 "whatever" :field2 "something else"}
+        {:keys [private-key public-key]} (util/generate-key-pair alg)
+        key-id       (str (UUID/randomUUID))
+        token        (util/encode-token payload {:alg         alg
+                                                 :private-key private-key
+                                                 :public-key  public-key
+                                                 :key-id      key-id})
+        key-fn (fn [_] public-key)]
+
+    (is (= (token/decode token {:alg    alg
+                                :key-fn key-fn})
+           payload)))
+  )
+
 (deftest decoding-token-signed-with-non-matching-key-causes-error
   (let [{:keys [private-key]} (util/generate-key-pair alg)
         {:keys [public-key]} (util/generate-key-pair alg)


### PR DESCRIPTION
This PR adds 2 features:
Option { :key-fn kid->pk } for :alg RSA256 to locate the public key without having to use a JWK endpoint
Option { :finder ring-req->String } fn for locating JWTs in other places than the 'Authorization' header.

I added a few tests and changed the README.me accordingly as well.
Not sure if you are accepting PRs, but it would be great!