### PR TITLE
Add support for multiple algorithms per middleware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.0.0 (2020-08-26)
+
+> IMPORTANT: This is a major release with backward compatibility breaking changes.
+
+## Added
+
+- Support for multiple issuers (each with their own configuration) in a single piece of middleware. The middleware will pull the issuer `iss`
+from the incoming JWT and use it to lookup the appropriate algorithm from the middleware configuration to use for decoding.
+(Note that the `iss` claim is not "trusted" until signature verification has succeeded.) 
+
+## Changed
+To support multiple issuers, the format of configuration has changed so that there is a separate configuration per issuer.
+See the [README](./README.md#usage) for an example.
+
+## Removed
+- `issuer` optional algorithm field has been removed. (Issuer check is now implicit based on the lookup of issuer in the
+configuration.) 
+ 
 # 1.3.0 (2020-07-14) [3bb7178](https://github.com/ovotech/ring-jwt/commit/545698b98baaba20028462d03facf72d42896e47)
 
 ## Changed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/ring-jwt "1.3.0"
+(defproject ovotech/ring-jwt "2.0.0"
   :description "JWT middleware for Ring"
   :url "http://github.com/ovotech/ring-jwt"
   :license {:name "Eclipse Public License"

--- a/src/ring/middleware/token.clj
+++ b/src/ring/middleware/token.clj
@@ -32,18 +32,18 @@
       (keywordize-non-namespaced-claims)))
 
 (defn- decode-token*
-  [algorithm token {:keys [issuer leeway-seconds]}]
-  (let [add-issuer #(if issuer
-                      (.withIssuer % (into-array String [issuer]))
-                      %)]
-    (-> algorithm
-        (JWT/require)
-        (.acceptLeeway (or leeway-seconds 0))
-        add-issuer
-        (.build)
-        (.verify token)
-        (.getPayload)
-        (base64->map))))
+  [algorithm token {:keys [leeway-seconds]}]
+  (-> algorithm
+      (JWT/require)
+      (.acceptLeeway (or leeway-seconds 0))
+      (.build)
+      (.verify token)
+      (.getPayload)
+      (base64->map)))
+
+(defn decode-issuer
+  [token]
+  (-> token JWT/decode (.getIssuer)))
 
 (s/def ::alg #{:RS256 :HS256 :ES256})
 (s/def ::issuer (s/and string? (complement clojure.string/blank?)))

--- a/test/ring/middleware/jwt_test.clj
+++ b/test/ring/middleware/jwt_test.clj
@@ -9,7 +9,6 @@
            (java.util Date UUID)))
 
 (def ^:private dummy-handler (constantly identity))
-(def ^:private issuer "issuer")
 
 (defn- build-request
   [claims alg-opts]
@@ -25,10 +24,10 @@
 
 (deftest claims-from-valid-jwt-token-in-authorization-header-are-added-to-request
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
+        issuer  (str (UUID/randomUUID))
         claims  {:a 1 :b 2 :iss issuer}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :issuer     issuer
-                                           :public-key public-key})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                             :public-key public-key}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         res     (handler req)]
@@ -36,10 +35,10 @@
 
 (deftest can-use-finder-function-to-locate-token
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
+        issuer  (str (UUID/randomUUID))
         claims  {:a 1 :b 2 :iss issuer}
-        handler (wrap-jwt (dummy-handler) {:alg           :RS256
-                                           :issuer        issuer
-                                           :public-key    public-key
+        handler (wrap-jwt (dummy-handler) {:issuers       {issuer {:alg        :RS256
+                                                                   :public-key public-key}}
                                            :find-token-fn (fn [{:keys [headers]}] (get headers "X-Whatever"))})
         token   (util/encode-token claims {:alg         :RS256
                                            :private-key private-key})
@@ -47,21 +46,12 @@
         res     (handler req)]
     (is (= claims (:claims res)))))
 
-(deftest validating-issuer-is-optional
-  (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:a 1 :b 2 :iss issuer}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :public-key public-key})
-        req     (build-request claims {:alg         :RS256
-                                       :private-key private-key})
-        res     (handler req)]
-    (is (= claims (:claims res)))))
-
 (deftest jwt-token-signed-with-wrong-algorithm-causes-401
   (let [{:keys [private-key]} (util/generate-key-pair :RS256)
-        claims  {:a 1 :b 2}
-        handler (wrap-jwt (dummy-handler) {:alg    :HS256
-                                           :secret (util/generate-hmac-secret)})
+        issuer  (str (UUID/randomUUID))
+        claims  {:a 1 :b 2 :iss issuer}
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                             :secret (util/generate-hmac-secret)}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         {:keys [body status]} (handler req)]
@@ -70,9 +60,10 @@
 
 (deftest jwt-token-signed-with-wrong-issuer-causes-401
   (let [{:keys [private-key]} (util/generate-key-pair :RS256)
+        issuer  (str (UUID/randomUUID))
         claims  {:a 1 :b 2 :iss issuer}
-        handler (wrap-jwt (dummy-handler) {:alg    :HS256
-                                           :secret (util/generate-hmac-secret)})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                             :secret (util/generate-hmac-secret)}}})
         req     (build-request claims {:alg         :RS256
                                        :issuer      (str "not" issuer)
                                        :private-key private-key})
@@ -82,15 +73,16 @@
 
 (deftest jwt-token-with-tampered-header-causes-401
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims          {:a 1 :b 2}
+        issuer          (str (UUID/randomUUID))
+        claims          {:a 1 :b 2 :iss issuer}
         token           (util/encode-token claims {:alg         :RS256
                                                    :private-key private-key})
         [_ payload signature] (split token #"\.")
         tampered-header (util/str->base64 (json/generate-string {:alg :RS256 :a 1}))
         tampered-token  (join "." [tampered-header payload signature])
 
-        handler         (wrap-jwt (dummy-handler) {:alg        :RS256
-                                                   :public-key public-key})
+        handler         (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                                     :public-key public-key}}})
         req             {:headers {"Authorization" (str "Bearer " tampered-token)}}
         {:keys [body status]} (handler req)]
     (is (= 401 status))
@@ -98,24 +90,26 @@
 
 (deftest jwt-token-with-tampered-payload-causes-401
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims           {:a 1 :b 2}
+        issuer           (str (UUID/randomUUID))
+        claims           {:a 1 :b 2 :iss issuer}
         token            (util/encode-token claims {:alg         :RS256
                                                     :private-key private-key})
 
         [header _ signature] (split token #"\.")
-        tampered-payload (util/str->base64 (json/generate-string {:a 1}))
+        tampered-payload (util/str->base64 (json/generate-string {:a 1 :iss issuer}))
         tampered-token   (join "." [header tampered-payload signature])
 
-        handler          (wrap-jwt (dummy-handler) {:alg        :RS256
-                                                    :public-key public-key})
+        handler          (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                                      :public-key public-key}}})
         req              {:headers {"Authorization" (str "Bearer " tampered-token)}}
         {:keys [body status]} (handler req)]
     (is (= 401 status))
     (is (= "Signature could not be verified." body))))
 
 (deftest no-jwt-token-causes-empty-claims-map-added-to-request
-  (let [handler (wrap-jwt (dummy-handler) {:alg    :HS256
-                                           :secret "whatever"})
+  (let [issuer  (str (UUID/randomUUID))
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                             :secret "whatever"}}})
         req     {:some "data"}
         res     (handler req)]
     (is (= req (dissoc res :claims)))
@@ -123,11 +117,13 @@
 
 (deftest expired-jwt-token-causes-401
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:exp (-> (epoch-seconds-instant)
+        issuer  (str (UUID/randomUUID))
+        claims  {:iss issuer
+                 :exp (-> (epoch-seconds-instant)
                           (.minusSeconds 1)
                           (instant->date))}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :public-key public-key})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                             :public-key public-key}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         {:keys [body status]} (handler req)]
@@ -136,11 +132,13 @@
 
 (deftest future-active-jwt-token-causes-401
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:nbf (-> (epoch-seconds-instant)
+        issuer  (str (UUID/randomUUID))
+        claims  {:iss issuer
+                 :nbf (-> (epoch-seconds-instant)
                           (.plusSeconds 1)
                           (instant->date))}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :public-key public-key})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                             :public-key public-key}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         {:keys [body status]} (handler req)]
@@ -152,12 +150,14 @@
 
 (deftest expired-jwt-token-within-specified-leeway-is-valid
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:exp (-> (epoch-seconds-instant)
+        issuer  (str (UUID/randomUUID))
+        claims  {:iss issuer
+                 :exp (-> (epoch-seconds-instant)
                           (.minusSeconds 100)
                           (instant->date))}
-        handler (wrap-jwt (dummy-handler) {:alg            :RS256
-                                           :public-key     public-key
-                                           :leeway-seconds 1000})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg            :RS256
+                                                             :public-key     public-key
+                                                             :leeway-seconds 1000}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         res     (handler req)]
@@ -165,12 +165,14 @@
 
 (deftest future-jwt-token-within-specified-leeway-is-valid
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:nbf (-> (epoch-seconds-instant)
+        issuer  (str (UUID/randomUUID))
+        claims  {:iss issuer
+                 :nbf (-> (epoch-seconds-instant)
                           (.plusSeconds 100)
                           (instant->date))}
-        handler (wrap-jwt (dummy-handler) {:alg            :RS256
-                                           :public-key     public-key
-                                           :leeway-seconds 1000})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg            :RS256
+                                                             :public-key     public-key
+                                                             :leeway-seconds 1000}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         res     (handler req)]
@@ -178,52 +180,58 @@
 
 (deftest test-object-and-vector-claims-can-be-added
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
-        claims  {:foo
-                      {:a 1 :b 2
+        issuer  (str (UUID/randomUUID))
+        claims  {:foo {:a 1 :b 2
                        :c {:d 3}
                        :e [4 5 6]}
-                 :bar [1 2 3]}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :public-key public-key})
+                 :bar [1 2 3]
+                 :iss issuer}
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                             :public-key public-key}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         res     (handler req)]
     (is (= claims (:claims res)))))
 
 (deftest allow-http-for-jwk
-  (wrap-jwt (dummy-handler) {:alg          :RS256
-                             :jwk-endpoint "http://my/jwk"
-                             :key-id       (str (UUID/randomUUID))}))
+  (let [issuer (str (UUID/randomUUID))]
+    (wrap-jwt (dummy-handler) {:issuers {issuer {:alg          :RS256
+                                                 :jwk-endpoint "http://my/jwk"
+                                                 :key-id       (str (str (UUID/randomUUID)))}}})))
 
 (testing "invalid options"
   (deftest missing-option-causes-error
-    (is (thrown-with-msg? ExceptionInfo #"Invalid options."
-                          (wrap-jwt (dummy-handler) {:alg    :HS256
-                                                     :bollox "whatever"}))))
+    (let [issuer (str (UUID/randomUUID))]
+      (is (thrown-with-msg? ExceptionInfo #"Invalid options."
+                            (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                                         :bollox "whatever"}}})))))
 
   (deftest incorrect-option-type-causes-error
-    (is (thrown-with-msg? ExceptionInfo #"Invalid options."
-                          (wrap-jwt (dummy-handler) {:alg    :HS256
-                                                     :secret 1}))))
+    (let [issuer (str (UUID/randomUUID))]
+      (is (thrown-with-msg? ExceptionInfo #"Invalid options."
+                            (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                                         :secret 1}}})))))
 
   (deftest option-from-wrong-algorithm-causes-error
-    (is (thrown-with-msg? ExceptionInfo #"Invalid options."
-                          (wrap-jwt (dummy-handler) {:alg    :RS256
-                                                     :secret "whatever"}))))
+    (let [issuer (str (UUID/randomUUID))]
+      (is (thrown-with-msg? ExceptionInfo #"Invalid options."
+                            (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :RS256
+                                                                         :secret "whatever"}}})))))
 
   (deftest extra-unsupported-option-does-not-cause-error
-    (wrap-jwt (dummy-handler) {:alg    :HS256
-                               :secret "somesecret"
-                               :bollox "whatever"})))
+    (let [issuer (str (UUID/randomUUID))]
+      (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                   :secret "somesecret"
+                                                   :bollox "whatever"}}}))))
 
 (deftest namespaced-claims-are-not-keywordized
   (let [{:keys [private-key public-key]} (util/generate-key-pair :RS256)
+        issuer  (str (UUID/randomUUID))
         claims  {"http://some/private/claim" 1
                  "another/namespaced-claim"  2
                  "iss"                       issuer}
-        handler (wrap-jwt (dummy-handler) {:alg        :RS256
-                                           :issuer     issuer
-                                           :public-key public-key})
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg        :RS256
+                                                             :public-key public-key}}})
         req     (build-request claims {:alg         :RS256
                                        :private-key private-key})
         res     (handler req)]
@@ -231,3 +239,45 @@
                (assoc :iss issuer)
                (dissoc "iss"))
            (:claims res)))))
+
+(deftest decoding-algorithm-is-selected-by-issuer
+  (let [{private-key1 :private-key public-key1 :public-key} (util/generate-key-pair :RS256)
+        {private-key2 :private-key public-key2 :public-key} (util/generate-key-pair :RS256)
+        issuer1 (str (UUID/randomUUID))
+        issuer2 (str (UUID/randomUUID))
+        claims1 {:a 1 :b 2 :iss issuer1}
+        claims2 {:a 1 :b 2 :iss issuer2}
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer1 {:alg        :RS256
+                                                              :public-key public-key1}
+                                                     issuer2 {:alg        :RS256
+                                                              :public-key public-key2}}})]
+    (is (= claims1 (->> {:alg         :RS256
+                         :private-key private-key1}
+                        (build-request claims1)
+                        (handler)
+                        :claims)))
+    (is (= claims2 (->> {:alg         :RS256
+                         :private-key private-key2}
+                        (build-request claims2)
+                        (handler)
+                        :claims)))))
+
+(deftest unknown-issuer-causes-401
+  (let [issuer  (str (UUID/randomUUID))
+        claims  {:a 1 :b 2 :iss "anotherissuer"}
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                             :secret "whatever"}}})
+        req     (build-request claims {:alg :HS256 :secret "whatever"})
+        {:keys [status body]} (handler req)]
+    (is (= 401 status))
+    (is (= "Unknown issuer." body))))
+
+(deftest issuer-is-case-sensitive
+  (let [issuer  "someissuer"
+        claims  {:a 1 :b 2 :iss (clojure.string/upper-case issuer)}
+        handler (wrap-jwt (dummy-handler) {:issuers {issuer {:alg    :HS256
+                                                             :secret "whatever"}}})
+        req     (build-request claims {:alg :HS256 :secret "whatever"})
+        {:keys [status body]} (handler req)]
+    (is (= 401 status))
+    (is (= "Unknown issuer." body))))


### PR DESCRIPTION
The algorithm gets selected based on the issuer found in the incoming JWT.

***What***: Allows the specification of multiple algorithms in the middleware configuration thus allowing decoding and verification of tokens from multiple issuers in a single piece of middleware.
***Why***: There are situations where JWT tokens will come from one of many auth providers rather than just the one.

> IMPORTANT: This introduces backward compatibility breaking changes - hence the bump to version `2.0.0`.
